### PR TITLE
Add rework-npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@
  */
 
 var calc = require('rework-calc');
+var conformance = require('rework-suit-conformance');
+var inliner = require('rework-npm');
 var rework = require('rework');
 var opacity = require('rework-mixin-opacity');
 var vars = require('rework-vars')();
@@ -24,6 +26,10 @@ module.exports = suit;
 
 function suit(ast, reworkInstance) {
   reworkInstance
+    // inline imports and require npm modules
+    .use(inliner({
+      prefilter: function (css) { return rework(css).use(conformance).toString(); }
+    }))
     // css variables
     .use(vars)
     // css calc

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
     "rework": "~0.20.2",
     "rework-vars": "~3.0.0",
     "rework-calc": "~0.2.1",
-    "rework-mixin-opacity": "~0.1.0"
+    "rework-mixin-opacity": "~0.1.0",
+    "rework-npm": "^0.6.1",
+    "rework-suit-conformance": "^0.2.0"
   },
   "devDependencies": {
     "chai": "~1.8.1",
-    "mocha": "~1.14.0"
+    "mocha": "~1.14.0",
+    "suitcss-utils-align": "0.1.1"
   },
   "scripts": {
     "test": "mocha --no-colors",

--- a/test/fixtures/expected.css
+++ b/test/fixtures/expected.css
@@ -1,4 +1,33 @@
 /**
+ * Test for import
+ */
+
+.imported {
+  padding: 0;
+}
+
+/**
+ * Vertical alignment utilities
+ * Depends on an appropriate `display` value.
+ */
+
+.u-alignBaseline {
+  vertical-align: baseline !important;
+}
+
+.u-alignBottom {
+  vertical-align: bottom !important;
+}
+
+.u-alignMiddle {
+  vertical-align: middle !important;
+}
+
+.u-alignTop {
+  vertical-align: top !important;
+}
+
+/**
  * Test for variables
  */
 

--- a/test/fixtures/import.css
+++ b/test/fixtures/import.css
@@ -1,0 +1,3 @@
+.imported {
+  padding: 0;
+}

--- a/test/fixtures/original.css
+++ b/test/fixtures/original.css
@@ -1,4 +1,11 @@
 /**
+ * Test for import
+ */
+
+@import "./test/fixtures/import";
+@import "suitcss-utils-align";
+
+/**
  * Test for variables
  */
 


### PR DESCRIPTION
Introduces the ability to inline `@import` statements, run conformance
checks on individual files, and to inline CSS files installed with npm.

An issue I'd like input on is how to pass the rework-npm options (or a subset) into this plugin bundle. The changeset shows how I've had to use the path from the repo root, rather than relative to the initial entry file (because rework-npm doesn't know where the entry file lives). Any ideas for a nice solution? cc @conradz

Fix gh-10
