### PR TITLE
Add the rework-inherit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ options available in [rework-npm](https://github.com/reworkcss/rework-npm).
 * [rework-calc](https://github.com/reworkcss/rework-calc): resolve basic `calc()` expressions.
 * [rework-suit-conformance](https://github.com/suitcss/rework-suit-conformance): SUIT CSS conformance checks on imported files.
 * [rework-ie-limits](https://github.com/reworkcss/rework-ie-limits): IE selector limit check.
+* [rework-inherit](https://github.com/reworkcss/rework-inherit): Inherit other CSS properties.
 
 Original:
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var inliner = require('rework-npm');
 var limits = require('rework-ie-limits');
 var rework = require('rework');
 var vars = require('rework-vars');
+var inherit = require('rework-inherit');
 
 /**
  * Module exports
@@ -49,6 +50,8 @@ function suit(options) {
       // variables
       .use(vars())
       // calc
-      .use(calc);
+      .use(calc)
+      // ability to inherit other selector's properties
+      .use(inherit());
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rework-suit",
   "description": "Rework plugin for SUIT CSS",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "index.js",
   "files": [
     "index.js"
@@ -11,6 +11,7 @@
     "rework-calc": "^1.0.0",
     "rework-custom-media": "~0.1.0",
     "rework-ie-limits": "~0.1.1",
+    "rework-inherit": "^0.2.3",
     "rework-npm": "^1.0.0",
     "rework-suit-conformance": "~0.4.0",
     "rework-vars": "^3.1.1"


### PR DESCRIPTION
I'm currently switching my project's CSS pre-processor from Less to Suit and I need inheritance capabilities. Any objections to adding it to the list of core plugins?
